### PR TITLE
fix: database cli prefix format

### DIFF
--- a/packages/database-cli/src/utils/common.ts
+++ b/packages/database-cli/src/utils/common.ts
@@ -9,11 +9,11 @@ export function createPrefix() {
   const date = new Date();
 
   const year = date.getFullYear();
-  const month = date.getMonth() + 1;
-  const day = date.getDate();
-  const hour = date.getHours();
-  const minute = date.getMinutes();
-  const second = date.getSeconds();
+  const month = (date.getMonth() + 1).toString().padStart(2, '0');
+  const day = date.getDate().toString().padStart(2, '0');
+  const hour = date.getHours().toString().padStart(2, '0');
+  const minute = date.getMinutes().toString().padStart(2, '0');
+  const second = date.getSeconds().toString().padStart(2, '0');
 
   return [year, month, day, hour, minute, second].join('');
 }


### PR DESCRIPTION
Fix the prefix formatting so it is in `YYYYMMDDHHmmss` format not conditionally `YYYYMMDDHHmmss`